### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+.hound.yml @rubizza-camp/rubizza-mentors-guild
+.reek.yml @rubizza-camp/rubizza-mentors-guild
+.rubocop.yml @rubizza-camp/rubizza-mentors-guild
+README.md @rubizza-camp/rubizza-mentors-guild
+.github/PULL_REQUEST_TEMPLATE.md @rubizza-camp/rubizza-mentors-guild


### PR DESCRIPTION
This commit add CODEOWNERS file wich prevent
unwanted changing of hound config files.

When someone will merge PR with .yml files in
root directory, it will requre approval from
@anatoliliotych, as an owner of the Hound).

Cause of that it there will be no need to fear
that some hound files are in PR

i hope this will be worked so. [DOCS](https://help.github.com/en/articles/about-code-owners)